### PR TITLE
Log Gateway requests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ricardoianelli @bijayshr @wizardofwaz8282

--- a/api-gateway-one/src/main/java/edu/miu/apigatewayone/RequestLoggingGlobalFilter.java
+++ b/api-gateway-one/src/main/java/edu/miu/apigatewayone/RequestLoggingGlobalFilter.java
@@ -1,0 +1,73 @@
+package edu.miu.apigatewayone;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+public class RequestLoggingGlobalFilter
+        implements GlobalFilter, Ordered {
+
+    final Logger logger =
+            LoggerFactory.getLogger(RequestLoggingGlobalFilter.class);
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange,
+                             GatewayFilterChain chain) {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+        logRequestInformation(exchange);
+        return chain.filter(exchange)
+                .then(Mono.fromRunnable(() -> logResponseInformation(exchange, stopWatch)));
+    }
+
+    public void logRequestInformation(ServerWebExchange exchange) {
+        try {
+            ServerHttpRequest request = exchange.getRequest();
+            String logMessage = "Request: " +
+                    request.getMethod() +
+                    " - " +
+                    request.getPath();
+
+            logger.info(logMessage);
+        } catch (Exception ex) {
+            logger.error("There was an exception logging a request: " + ex);
+        }
+
+    }
+
+    public void logResponseInformation(ServerWebExchange exchange, StopWatch currentStopWatch) {
+        try {
+            currentStopWatch.stop();
+            ServerHttpRequest request = exchange.getRequest();
+            ServerHttpResponse response = exchange.getResponse();
+            String logMessage = "Response: " +
+                    "[" +
+                    response.getStatusCode() +
+                    "] " +
+                    request.getMethod() +
+                    " - " +
+                    request.getPath() +
+                    " - " +
+                    currentStopWatch.getTotalTimeMillis() +
+                    " ms.";
+
+            logger.info(logMessage);
+        } catch (Exception ex) {
+            logger.error("There was an exception logging a response: " + ex);
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return -1;
+    }
+}

--- a/api-gateway-one/src/test/java/edu/miu/apigatewayone/RequestLoggingGlobalFilterTests.java
+++ b/api-gateway-one/src/test/java/edu/miu/apigatewayone/RequestLoggingGlobalFilterTests.java
@@ -1,0 +1,31 @@
+package edu.miu.apigatewayone;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.RequestPath;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequestLoggingGlobalFilterTests {
+
+    RequestLoggingGlobalFilter requestLoggingGlobalFilter = new RequestLoggingGlobalFilter();
+
+    @Test
+    public void UponReceivingARequest_ShouldLogItsInfo() {
+
+        ServerWebExchange exchangeMock = mock(ServerWebExchange.class);
+        ServerHttpRequest requestMock = mock(ServerHttpRequest.class);
+        RequestPath requestPathMock = mock(RequestPath.class);
+
+        when(requestPathMock.toString()).thenReturn("/api/v1/users");
+        when(requestMock.getPath()).thenReturn(requestPathMock);
+        when(requestMock.getMethod()).thenReturn(HttpMethod.GET);
+
+        assertDoesNotThrow(() -> requestLoggingGlobalFilter.logRequestInformation(exchangeMock));
+    }
+}

--- a/api-gateway-one/src/test/java/edu/miu/apigatewayone/RequestLoggingGlobalFilterTests.java
+++ b/api-gateway-one/src/test/java/edu/miu/apigatewayone/RequestLoggingGlobalFilterTests.java
@@ -1,7 +1,6 @@
 package edu.miu.apigatewayone;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.server.RequestPath;
 import org.springframework.http.server.reactive.ServerHttpRequest;


### PR DESCRIPTION
Add logging to all the requests that go through API Gateway.
Here's an example of how the requests/responses are logged:

![image](https://user-images.githubusercontent.com/2482654/173122741-6100c25d-02d0-4c96-9853-cd7397cb3a56.png)

I've included only 1 test case checking if an exception will be thrown since I was having trouble checking how to test if a message was logged.

I also included a CODEOWNERS file so we don't have to manually add reviewers to the pull requests.